### PR TITLE
Read and process program settings configuration files

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -18,6 +18,11 @@
 #define MAX_OPT_LEN 256
 #define OPT_SKIP 69
 
+/* Configuration file location bit flags */
+#define CFG_LOC_HOME 0x01
+#define CFG_LOC_ETC 0x02
+#define CFG_LOC_DEFAULT 0x04
+
 /* Exit Codes */
 #define EXT_NULL_CFG 1
 #define EXT_CFG_ALLOC 2
@@ -29,11 +34,14 @@
  * [paths_size] number of elements contained in [paths].
  * [events_bmask] bit mask that indicates what file events the daemon will
  * trigger notifications for.
+ * [config_loc] the config file used for current session. Corresponds to CFG_LOC
+ * bit flag
  */
 typedef struct {
   char **paths;
   int paths_size;
   u8 events_bmask;
+  u8 config_loc;
 } Config;
 
 /*
@@ -66,7 +74,7 @@ void free_config(Config *cfg);
  * the config files are not present, the function will defer to sensible
  * defaults.
  */
-char *read_config(void);
+char *get_config_settings(Config *cfg);
 
 /*
  * Setting options are a list of line separated strings. Some settings can have

--- a/include/util.h
+++ b/include/util.h
@@ -2,11 +2,25 @@
 #define UTIL_H
 #include <stdint.h>
 
+#define EXT_INVAL_PATH
+
 typedef uint8_t u8;
 
 /*
- * Convenience function
+ * Convenience function to simply check if a file exists
  */
 int file_exists(const char *filename);
+
+/*
+ * Convenience function for reading a file and returning
+ * heap allocated string. YOU are responsible for freeing
+ * the memory afterwards.
+ */
+char *read_file(const char *filename);
+
+/*
+ * Convenience function for expanding paths. eg. "~/.ssh"
+ */
+char *expand_path(const char *path);
 
 #endif

--- a/include/util.h
+++ b/include/util.h
@@ -19,7 +19,7 @@ int file_exists(const char *filename);
 char *read_file(const char *filename);
 
 /*
- * Convenience function for expanding paths. eg. "~/.ssh"
+ * Convenience function for expanding paths. eg. "~/.ssh" -> "$HOME/.ssh/"
  */
 char *expand_path(const char *path);
 

--- a/src/config.c
+++ b/src/config.c
@@ -202,41 +202,41 @@ void set_events_option(Config *cfg, char *value) {
 
 void debug_config(Config *cfg) {
   if (cfg == NULL) {
-    fprintf(stderr, "[DEBUG-ERROR]: Configuration struct is null\n");
+    fprintf(stderr, "[DEBUG]: Configuration struct is null\n");
   }
 
-  fprintf(stdout, "[INFO]: Paths option settings\n");
-  fprintf(stdout, "[INFO]: Number of paths set for monitoring [%d]\n",
+  fprintf(stdout, "[DEBUG]: Paths option settings\n");
+  fprintf(stdout, "[DEBUG]: Number of paths set for monitoring [%d]\n",
           cfg->paths_size);
 
   for (int i = 0; i < cfg->paths_size; i++) {
-    fprintf(stdout, "[INFO]: Path @ index [%d] contains value [%s]\n", i,
+    fprintf(stdout, "[DEBUG]: Path @ index [%d] contains value [%s]\n", i,
             cfg->paths[i]);
   }
   fprintf(stdout, "\n");
 
-  fprintf(stdout, "[INFO]: File event option settings\n");
+  fprintf(stdout, "[DEBUG]: File event option settings\n");
   if (cfg->events_bmask == 0) {
     fprintf(stderr, "[WARNING]: File event flags are not enabled\n");
     return;
   } else {
-    fprintf(stdout, "[INFO]: File Event Bit Flags [0x%08X]\n",
+    fprintf(stdout, "[DEBUG]: File Event Bit Flags [0x%08X]\n",
             cfg->events_bmask);
   }
 
   if (cfg->events_bmask & FLAG_ACCESS) {
-    fprintf(stdout, "[INFO]: File access event flag enabled\n");
+    fprintf(stdout, "[DEBUG]: File access event flag enabled\n");
   }
 
   if (cfg->events_bmask & FLAG_MODIFY) {
-    fprintf(stdout, "[INFO]: File modify event flag enabled\n");
+    fprintf(stdout, "[DEBUG]: File modify event flag enabled\n");
   }
 
   if (cfg->events_bmask & FLAG_MOVE) {
-    fprintf(stdout, "[INFO]: File move event flag enabled\n");
+    fprintf(stdout, "[DEBUG]: File move event flag enabled\n");
   }
 
   if (cfg->events_bmask & FLAG_CLOSE) {
-    fprintf(stdout, "[INFO]: File close event flag enabled\n");
+    fprintf(stdout, "[DEBUG]: File close event flag enabled\n");
   }
 }

--- a/src/util.c
+++ b/src/util.c
@@ -39,35 +39,35 @@ char *expand_path(const char *path) {
 }
 
 char *read_file(const char *filename) {
-  char *expanded_path = expand_path(filename);
-  if (expanded_path == NULL) {
+  char *cleaned_path = expand_path(filename);
+  if (cleaned_path == NULL) {
     fprintf(stderr, "[ERROR]: Failed to expand path\n");
     return NULL;
   }
 
   struct stat stat_buf;
-  int ok = stat(expanded_path, &stat_buf);
+  int ok = stat(cleaned_path, &stat_buf);
   if (ok == -1) {
-    fprintf(stderr, "[ERROR]: File [%s] does not exist\n", expanded_path);
+    fprintf(stderr, "[ERROR]: File [%s] does not exist\n", cleaned_path);
     return NULL;
   }
 
   char *buf = (char *)malloc(stat_buf.st_size + 1);
   if (buf == NULL) {
     fprintf(stderr, "[ERROR]: Failed to allocate memory for [%s] buffer\n",
-            expanded_path);
+            cleaned_path);
   }
 
-  int fd = open(expanded_path, O_RDONLY);
+  int fd = open(cleaned_path, O_RDONLY);
   if (fd == -1) {
-    fprintf(stderr, "[ERROR]: Failed to open file [%s]\n", expanded_path);
+    fprintf(stderr, "[ERROR]: Failed to open file [%s]\n", cleaned_path);
     free(buf);
     return NULL;
   }
 
   ssize_t bytes_read = read(fd, buf, stat_buf.st_size + 1);
   if (bytes_read == -1) {
-    fprintf(stderr, "[ERROR]: Failed to read file [%s]\n", expanded_path);
+    fprintf(stderr, "[ERROR]: Failed to read file [%s]\n", cleaned_path);
     close(fd);
     free(buf);
     return NULL;
@@ -75,6 +75,6 @@ char *read_file(const char *filename) {
 
   buf[bytes_read] = '\0';
   close(fd);
-  free(expanded_path);
+  free(cleaned_path);
   return buf;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -1,7 +1,80 @@
 #include "util.h"
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 int file_exists(const char *filename) {
   struct stat buf;
   return (stat(filename, &buf) == 0);
+}
+
+char *expand_path(const char *path) {
+  if (strlen(path) == 0) {
+    fprintf(stderr, "[ERROR]: Cannot expand a path that is empty\n");
+    return NULL;
+  }
+
+  char *full_path = (char *)malloc(sizeof(char) * 512);
+  if (full_path == NULL) {
+    fprintf(stderr, "[ERROR]: Failed to allocate memory for expanded path\n");
+    return NULL;
+  }
+
+  if (path[0] != '~') {
+    strcpy(full_path, path);
+    return full_path;
+  }
+
+  char *home_path = getenv("HOME");
+  if (home_path == NULL) {
+    fprintf(stderr, "[ERROR]: Failed to find $HOME in list of env variables\n");
+    return NULL;
+  }
+
+  snprintf(full_path, 512, "%s%s", home_path, path + 1);
+  return full_path;
+}
+
+char *read_file(const char *filename) {
+  char *expanded_path = expand_path(filename);
+  if (expanded_path == NULL) {
+    fprintf(stderr, "[ERROR]: Failed to expand path\n");
+    return NULL;
+  }
+
+  struct stat stat_buf;
+  int ok = stat(expanded_path, &stat_buf);
+  if (ok == -1) {
+    fprintf(stderr, "[ERROR]: File [%s] does not exist\n", expanded_path);
+    return NULL;
+  }
+
+  char *buf = (char *)malloc(stat_buf.st_size + 1);
+  if (buf == NULL) {
+    fprintf(stderr, "[ERROR]: Failed to allocate memory for [%s] buffer\n",
+            expanded_path);
+  }
+
+  int fd = open(expanded_path, O_RDONLY);
+  if (fd == -1) {
+    fprintf(stderr, "[ERROR]: Failed to open file [%s]\n", expanded_path);
+    free(buf);
+    return NULL;
+  }
+
+  ssize_t bytes_read = read(fd, buf, stat_buf.st_size + 1);
+  if (bytes_read == -1) {
+    fprintf(stderr, "[ERROR]: Failed to read file [%s]\n", expanded_path);
+    close(fd);
+    free(buf);
+    return NULL;
+  }
+
+  buf[bytes_read] = '\0';
+  close(fd);
+  free(expanded_path);
+  return buf;
 }


### PR DESCRIPTION
# Description

The changes in this pull request allow the user of the program to specify configuration files in specific locations on unix-like systems. 

User specific program settings can be stored in `$HOME/.file-warden.conf`

System wide program settings can be stored in `/etc/file-warden.conf`

If either of the mentioned files are not present on the file system, we will default to sensible settings.