### PR TITLE
Read file system events from specified paths

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -38,8 +38,8 @@
  * [paths_size] number of elements contained in [paths].
  * [events_bmask] bit mask that indicates what file events the daemon will
  * trigger notifications for.
- * [config_loc] the config file used for current session. Corresponds to CFG_LOC
- * bit flag
+ * [config_location] the config file used for current session. Corresponds to
+ * CFG_LOC bit flag.
  */
 typedef struct {
   char **paths;

--- a/include/event.h
+++ b/include/event.h
@@ -1,0 +1,54 @@
+#ifndef EVENT_H
+#define EVENT_H
+
+#include "config.h"
+#include <sys/inotify.h>
+#include <sys/poll.h>
+
+#define POLL_INTERVAL_MS 500
+#define MAX_WATCH_DESCRIPTORS 50
+
+/*
+ * [wd] inotify watch descriptor
+ * [path] the path to the dir or file that [wd] is set too.
+ */
+typedef struct {
+  int wd;
+  char *path;
+} WdEntry;
+
+/*
+ * [fd] inotify file descriptor
+ * [wd] list of inotify watch descriptors
+ * [nfds] Type used for the number of file descriptors.
+ * [fds] describes a polling request.
+ * [poll_n] @TODO: create a note that describes [poll_n] responsibility
+ * [wd_map] look up table that links inotify watch descriptors to paths. It
+ * provides a simple way to determine which path triggered an event.
+ */
+typedef struct {
+  int fd;
+  int *wd;
+  nfds_t nfds;
+  struct pollfd fds[1];
+  int poll_n;
+  WdEntry wd_map[MAX_WATCH_DESCRIPTORS];
+} EventState;
+
+/*
+ * Allocates memory for [EventState], creates/initializes a new inotify
+ * instance, allocates memory for watch descriptors [wd], adds all paths
+ * contained in input [cfg] to inotify watch events, and creates the [WdEntry]
+ * mapping. On error, a null pointer is returned. If no error, you are
+ * responsible for freeing memory after use. [stop_event_listener] will perform
+ * clean up duties.
+ */
+EventState *start_event_listener(Config *cfg);
+
+/*
+ * Closes the inotify file descriptor and frees up allocated memory for input
+ * [state].
+ */
+void stop_event_listener(EventState *state);
+
+#endif

--- a/include/event.h
+++ b/include/event.h
@@ -64,4 +64,14 @@ void stop_event_listener(EventState *state);
  */
 char *get_wd_path_mapping(EventState *state, int wd);
 
+/*
+ * Handles file system events using the inotify API. It continuously reads
+ * events from the inotify file descritor, contained within the input [state],
+ * processed each event to determine the type of file operation, retrieves the
+ * accosicated file path from the events watch descriptor, and logs information
+ * about the event.
+ *
+ */
+int handle_events(EventState *state);
+
 #endif

--- a/include/event.h
+++ b/include/event.h
@@ -8,6 +8,9 @@
 #define POLL_INTERVAL_MS 500
 #define MAX_WATCH_DESCRIPTORS 50
 
+/* Exit codes */
+#define EXT_START_LISTENER 9
+
 /*
  * [wd] inotify watch descriptor
  * [path] the path to the dir or file that [wd] is set too.
@@ -39,9 +42,9 @@ typedef struct {
  * Allocates memory for [EventState], creates/initializes a new inotify
  * instance, allocates memory for watch descriptors [wd], adds all paths
  * contained in input [cfg] to inotify watch events, and creates the [WdEntry]
- * mapping. On error, a null pointer is returned. If no error, you are
- * responsible for freeing memory after use. [stop_event_listener] will perform
- * clean up duties.
+ * mapping. On error, a null pointer is returned and any memory used to create
+ * [EventState] is freed. If no error, you are responsible for freeing memory
+ * after use. [stop_event_listener] will perform clean up duties.
  */
 EventState *start_event_listener(Config *cfg);
 

--- a/include/event.h
+++ b/include/event.h
@@ -56,4 +56,12 @@ EventState *start_event_listener(Config *cfg);
  */
 void stop_event_listener(EventState *state);
 
+/*
+ * Uses input [state] and [wd] to retrieve the path name that is linked to
+ * inotify watch descriptor [wd]. If no mapping is found, NULL is returned.
+ * Otherwise a pointer to the path is returned from field [wd_map] contained in
+ * [state].
+ */
+char *get_wd_path_mapping(EventState *state, int wd);
+
 #endif

--- a/include/event.h
+++ b/include/event.h
@@ -28,6 +28,7 @@ typedef struct {
  * [poll_n] @TODO: create a note that describes [poll_n] responsibility
  * [wd_map] look up table that links inotify watch descriptors to paths. It
  * provides a simple way to determine which path triggered an event.
+ * [wd_entry_count] number of active elements contained in [wd_map].
  */
 typedef struct {
   int fd;
@@ -36,6 +37,7 @@ typedef struct {
   struct pollfd fds[1];
   int poll_n;
   WdEntry wd_map[MAX_WATCH_DESCRIPTORS];
+  int wd_entry_count;
 } EventState;
 
 /*

--- a/include/event.h
+++ b/include/event.h
@@ -13,7 +13,9 @@
 
 /*
  * [wd] inotify watch descriptor
- * [path] the path to the dir or file that [wd] is set too.
+ * [path] uses the [Config] struct to look up the path name of the watch
+ * descriptor. inotify event object doesn't provide the name of the path after
+ * reading a system event.
  */
 typedef struct {
   int wd;
@@ -25,10 +27,12 @@ typedef struct {
  * [wd] list of inotify watch descriptors
  * [nfds] Type used for the number of file descriptors.
  * [fds] describes a polling request.
- * [poll_n] @TODO: create a note that describes [poll_n] responsibility
- * [wd_map] look up table that links inotify watch descriptors to paths. It
- * provides a simple way to determine which path triggered an event.
- * [wd_entry_count] number of active elements contained in [wd_map].
+ * [poll_n] return value of [poll] used to monitor multiple file descriptors if
+ * they are ready for reading.
+ * [wd_map] look up table that links inotify watch
+ * descriptors to paths. It provides a simple way to determine which path
+ * triggered an event. [wd_entry_count] number of active elements contained in
+ * [wd_map].
  */
 typedef struct {
   int fd;

--- a/src/event.c
+++ b/src/event.c
@@ -65,3 +65,19 @@ EventState *start_event_listener(Config *cfg) {
   return state;
 }
 
+void stop_event_listener(EventState *state) {
+  if (state == NULL) {
+    return;
+  }
+
+  if (state->fd != -1) {
+    close(state->fd);
+    syslog(LOG_INFO, "File event listener has stopped...\n");
+  }
+
+  if (state->wd != NULL) {
+    free(state->wd);
+  }
+
+  free(state);
+}

--- a/src/event.c
+++ b/src/event.c
@@ -95,3 +95,13 @@ void stop_event_listener(EventState *state) {
 
   free(state);
 }
+
+char *get_wd_path_mapping(EventState *state, int wd) {
+  for (int i = 0; i < state->wd_entry_count; i++) {
+    if (state->wd_map[i].wd == wd) {
+      return state->wd_map[i].path;
+    }
+  }
+
+  return NULL;
+}

--- a/src/event.c
+++ b/src/event.c
@@ -1,0 +1,67 @@
+#include "event.h"
+#include "config.h"
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/inotify.h>
+#include <sys/syslog.h>
+#include <unistd.h>
+
+EventState *start_event_listener(Config *cfg) {
+  EventState *state = malloc(sizeof(EventState));
+  if (state == NULL) {
+    syslog(LOG_ERR, "Failed to allocate memory for inotify event state\n");
+    return NULL;
+  }
+
+  state->fd = inotify_init1(IN_NONBLOCK);
+  if (state->fd == -1) {
+    syslog(LOG_ERR, "Failed to create and initialize inotify instance\n");
+    stop_event_listener(state);
+    return NULL;
+  }
+
+  state->wd = calloc(cfg->paths_size, sizeof(int));
+  if (state->wd == NULL) {
+    syslog(LOG_ERR,
+           "Failed to allocate memory for inotify watch descriptors\n");
+    stop_event_listener(state);
+    return NULL;
+  }
+
+  for (int i = 0; i < cfg->paths_size; i++) {
+    if (i > MAX_WATCH_DESCRIPTORS - 1) {
+      syslog(LOG_ERR, "Cannot watch more than [%d] files/directories\n",
+             MAX_WATCH_DESCRIPTORS);
+      stop_event_listener(state);
+      return NULL;
+    }
+
+    // @TODO: utilize configuration events instead of hardcoding the event mask
+    state->wd[i] = inotify_add_watch(state->fd, cfg->paths[i], IN_ACCESS);
+    if (state->wd[i] == -1) {
+      syslog(LOG_ERR, "Failed to add [%s] to inotify watch list. [error: %s]\n",
+             cfg->paths[i], strerror(errno));
+      stop_event_listener(state);
+      return NULL;
+    }
+
+    if (cfg->paths[i] == NULL) {
+      syslog(LOG_ERR,
+             "Expected index [%d] to contain a valid path but got null\n", i);
+      stop_event_listener(state);
+      return NULL;
+    }
+
+    state->wd_map[i].wd = state->wd[i];
+    state->wd_map[i].path = cfg->paths[i];
+  }
+
+  state->nfds = 1;
+  state->fds[0].fd = state->fd;
+  state->fds[0].events = POLLIN;
+
+  syslog(LOG_INFO, "File event listener has started...\n");
+  return state;
+}
+

--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,8 @@ int main(int argc, char **argv) {
     exit(EXT_START_LISTENER);
   }
 
+  // @TODO: rm config debugging once events are working as expected
+  debug_config(cfg);
   while (running) {
     state->poll_n = poll(state->fds, state->nfds, POLL_INTERVAL_MS);
     if (state->poll_n == -1) {

--- a/src/main.c
+++ b/src/main.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
   }
 
   syslog(LOG_INFO, "Cleaning up...\n");
-  free_config(cfg);
   stop_event_listener(state);
+  free_config(cfg);
   exit(EXIT_SUCCESS);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "event.h"
 #include "util.h"
 #include <signal.h>
 #include <stdlib.h>
@@ -39,6 +40,13 @@ int main(int argc, char **argv) {
     syslog(LOG_ERR, "Failed to initialize signals\n");
     free_config(cfg);
     exit(sig_status);
+  }
+
+  EventState *state = start_event_listener(cfg);
+  if (state == NULL) {
+    syslog(LOG_ERR, "Failed to start file event listener\n");
+    free_config(cfg);
+    exit(EXT_START_LISTENER);
   }
 
   while (running) {

--- a/src/main.c
+++ b/src/main.c
@@ -54,6 +54,8 @@ int main(int argc, char **argv) {
     sleep(120);
   }
 
+  syslog(LOG_INFO, "Cleaning up...\n");
   free_config(cfg);
+  stop_event_listener(state);
   exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
# Description

This pull request introduces functionality to utilize the program's configuration settings, specifically the paths that a user wants to monitor for file system events, and implements the inotify API to log details about these system events to the journal. 

Currently the system event listeners are hardcoded. Future pull requests will address this limitation by utilizing the events configuration settings. The logic to process the `events` options from a users configuration is already complete, so it's just a matter of implementing this into event handler that this pull request introduced. 
