### PR TITLE
Displaying file system events with libnotify

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install -y gcc make
+      run: sudo apt-get update && sudo apt-get install -y gcc make libnotify-dev
 
     - name: Build the project
       run: make

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ C_FLAGS = -Wall -pedantic -std=gnu99 -I$(INCLUDE_DIR)
 
 C_SOURCES = $(shell find $(SRC_DIR) -name '*.c')
 OBJS = $(C_SOURCES:$(SRC_DIR)%.c=$(BUILD_DIR)%.o)
+LIBS = $(shell pkg-config --cflags --libs libnotify)
 
 EXEC = $(BUILD_DIR)/file-warden
 
@@ -15,7 +16,7 @@ all: $(EXEC)
 
 $(EXEC): $(C_SOURCES)
 	@mkdir -p $(BUILD_DIR)
-	$(CC) $(C_SOURCES) -o $(EXEC) $(C_FLAGS)
+	$(CC) $(C_SOURCES) -o $(EXEC) $(C_FLAGS) $(LIBS)
 
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
 	$(CC) -c $< -o $@ $(CFLAGS)

--- a/include/notify.h
+++ b/include/notify.h
@@ -1,0 +1,32 @@
+#ifndef NOTIFY_H
+#define NOTIFY_H
+
+#include <libnotify/notification.h>
+
+/* Exit/Err codes */
+#define EXT_INIT_NOTIF 10
+#define EXT_CREAT_NOTIF 11
+#define EXT_DISPLAY_NOTIF 12
+
+/* Time, in MS, before notification is removed from screen */
+#define NOTIF_TIMEOUT_MS 3000
+
+/*
+ * Wrapper function to init libnotify, invokes [notify_init]. Returns 0 if
+ * successful, otherwise it will return [EXT_INIT_NOTIF] which is then used as
+ * an exit code.
+ */
+int init_notif(void);
+
+/*
+ * Wrapper function to uninitialize libnotify, invokes [notify_uninit].
+ */
+void uninit_notif(void);
+
+/*
+ * Creates a new [NotifyNotification] struct using input [title] and [body]
+ * as the text that will displayed in the notification.
+ */
+int display_notification(const char *title, const char *body);
+
+#endif

--- a/src/config.c
+++ b/src/config.c
@@ -27,28 +27,28 @@ static const char *CFG_HOME_PATH = "~/.file-warden.conf";
 Config *init_config(void) {
   Config *cfg = (Config *)malloc(sizeof(Config));
   if (cfg == NULL) {
-    syslog(LOG_ERR, "Failed to allocate memory for config struct\n");
+    syslog(LOG_ERR, "Failed to allocate memory for config struct");
     exit(EXT_CFG_ALLOC);
   }
 
   cfg->paths_size = 0;
   cfg->paths = (char **)malloc(sizeof(char *));
   if (cfg->paths == NULL) {
-    syslog(LOG_ERR, "Failed to allocate memory for watch paths\n");
+    syslog(LOG_ERR, "Failed to allocate memory for watch paths");
     free_config(cfg);
     exit(EXT_CFG_ALLOC);
   }
 
   char *program_settings = get_config_settings(cfg);
   if (program_settings == NULL) {
-    syslog(LOG_ERR, "Failed to fetch program option settings\n");
+    syslog(LOG_ERR, "Failed to fetch program option settings");
     free_config(cfg);
     exit(EXT_NULL_CFG);
   }
 
   int result = process_settings(cfg, program_settings);
   if (result != 0) {
-    syslog(LOG_ERR, "Failed to process program option settings\n");
+    syslog(LOG_ERR, "Failed to process program option settings");
     free_config(cfg);
     exit(result);
   }
@@ -79,14 +79,14 @@ char *get_config_settings(Config *cfg) {
 
     char *settings = read_file(in_home ? CFG_HOME_PATH : CFG_ETC_PATH);
     if (settings != NULL) {
-      syslog(LOG_INFO, "Using config file at [%s]\n",
+      syslog(LOG_INFO, "Using config file at [%s]",
              in_home ? CFG_HOME_PATH : CFG_ETC_PATH);
 
       return settings;
     }
 
     syslog(LOG_WARNING, "Failed to read setting from config file. Deferring to "
-                        "default settings\n");
+                        "default settings");
   }
 
   syslog(LOG_WARNING,
@@ -100,12 +100,12 @@ char *get_config_settings(Config *cfg) {
 
 int process_settings(Config *cfg, const char *settings) {
   if (cfg == NULL) {
-    syslog(LOG_ERR, "Expected config struct not to be null\n");
+    syslog(LOG_ERR, "Expected config struct not to be null");
     return EXT_NULL_CFG;
   }
 
   if (settings == NULL) {
-    syslog(LOG_ERR, "Expected program settings not to be empty\n");
+    syslog(LOG_ERR, "Expected program settings not to be empty");
     return EXT_NULL_CFG;
   }
 
@@ -131,7 +131,7 @@ int process_line_option(Config *cfg, char *line) {
 
   char *equal_sign = strchr(line, '=');
   if (equal_sign == NULL) {
-    syslog(LOG_ERR, "Invalid option format. Expected \"option=val1,val2\"\n");
+    syslog(LOG_ERR, "Invalid option format. Expected \"option=val1,val2\"");
     return EXT_OPT_FORMAT;
   }
 
@@ -139,7 +139,7 @@ int process_line_option(Config *cfg, char *line) {
   key[equal_sign - line] = '\0';
   u8 opt_flag = validate_option(key);
   if (opt_flag == FLAG_INVAL_OPT) {
-    syslog(LOG_WARNING, "Invalid option setting [%s]\n", key);
+    syslog(LOG_WARNING, "Invalid option setting [%s]", key);
   }
 
   strcpy(values, equal_sign + 1);
@@ -163,7 +163,7 @@ u8 validate_option(char *setting_key) {
     return FLAG_EVENTS_OPT;
   }
 
-  syslog(LOG_WARNING, "Invalid option setting with value [%s]\n", setting_key);
+  syslog(LOG_WARNING, "Invalid option setting with value [%s]", setting_key);
   return 0;
 }
 
@@ -176,14 +176,14 @@ int set_option(Config *cfg, u8 option_flag, char *value) {
     return set_events_option(cfg, value);
   }
 
-  syslog(LOG_WARNING, "skipping value [%s]. Unknown option setting\n", value);
+  syslog(LOG_WARNING, "skipping value [%s]. Unknown option setting", value);
   return 0;
 }
 
 int set_paths_option(Config *cfg, char *value) {
   char *expanded_path = expand_path(value);
   if (expanded_path == NULL) {
-    syslog(LOG_ERR, "Failed to expand path [%s]\n", value);
+    syslog(LOG_ERR, "Failed to expand path [%s]", value);
     return EXT_SET_PATH_OPT;
   }
 
@@ -220,40 +220,39 @@ int set_events_option(Config *cfg, char *value) {
 
 void debug_config(Config *cfg) {
   if (cfg == NULL) {
-    syslog(LOG_DEBUG, "Configuration struct is null\n");
+    syslog(LOG_DEBUG, "Configuration struct is null");
   }
 
-  syslog(LOG_DEBUG, "Paths option settings\n");
-  syslog(LOG_DEBUG, "Number of paths set for monitoring [%d]\n",
+  syslog(LOG_DEBUG, "Paths option settings");
+  syslog(LOG_DEBUG, "Number of paths set for monitoring [%d]",
          cfg->paths_size);
 
   for (int i = 0; i < cfg->paths_size; i++) {
-    syslog(LOG_DEBUG, "Path @ index [%d] contains value [%s]\n", i,
+    syslog(LOG_DEBUG, "Path @ index [%d] contains value [%s]", i,
            cfg->paths[i]);
   }
-  syslog(LOG_DEBUG, "\n");
 
-  syslog(LOG_DEBUG, "File event option settings\n");
+  syslog(LOG_DEBUG, "File event option settings");
   if (cfg->events_bmask == 0) {
-    syslog(LOG_DEBUG, "File event flags are not enabled\n");
+    syslog(LOG_DEBUG, "File event flags are not enabled");
     return;
   } else {
-    syslog(LOG_DEBUG, "File Event Bit Flags [0x%08X]\n", cfg->events_bmask);
+    syslog(LOG_DEBUG, "File Event Bit Flags [0x%08X]", cfg->events_bmask);
   }
 
   if (cfg->events_bmask & FLAG_ACCESS) {
-    syslog(LOG_DEBUG, "File access event flag enabled\n");
+    syslog(LOG_DEBUG, "File access event flag enabled");
   }
 
   if (cfg->events_bmask & FLAG_MODIFY) {
-    syslog(LOG_DEBUG, "File modify event flag enabled\n");
+    syslog(LOG_DEBUG, "File modify event flag enabled");
   }
 
   if (cfg->events_bmask & FLAG_MOVE) {
-    syslog(LOG_DEBUG, "File move event flag enabled\n");
+    syslog(LOG_DEBUG, "File move event flag enabled");
   }
 
   if (cfg->events_bmask & FLAG_CLOSE) {
-    syslog(LOG_DEBUG, "File close event flag enabled\n");
+    syslog(LOG_DEBUG, "File close event flag enabled");
   }
 }

--- a/src/event.c
+++ b/src/event.c
@@ -112,7 +112,7 @@ char *get_wd_path_mapping(EventState *state, int wd) {
 }
 
 /*
- * @TODO: event handler should use cfg option settings for notifications
+ * @TODO:(#8) event handler should use cfg option settings for notifications
  * Currently, the file system events that are listened to, by inotify, are
  * hardcoded. This was for testing purposes so that I could acclimate myself to
  * the inotify & libnotify APIs. Ideally, we should use the event mask, read in

--- a/src/event.c
+++ b/src/event.c
@@ -80,13 +80,17 @@ void stop_event_listener(EventState *state) {
     return;
   }
 
+  for (int i = 0; i < state->wd_entry_count; i++) {
+    int status = inotify_rm_watch(state->fd, state->wd[i]);
+    if (status == -1) {
+      syslog(LOG_ERR, "Failed to remove watch descriptor from inotify event\n");
+    }
+    free(state->wd_map[i].path);
+  }
+
   if (state->fd != -1) {
     close(state->fd);
     syslog(LOG_INFO, "File event listener has stopped...\n");
-  }
-
-  for (int i = 0; i < state->wd_entry_count; i++) {
-    free(state->wd_map[i].path);
   }
 
   if (state->wd != NULL) {

--- a/src/event.c
+++ b/src/event.c
@@ -111,6 +111,18 @@ char *get_wd_path_mapping(EventState *state, int wd) {
   return NULL;
 }
 
+/*
+ * @TODO: event handler should use cfg option settings for notifications
+ * Currently, the file system events that are listened to, by inotify, are
+ * hardcoded. This was for testing purposes so that I could acclimate myself to
+ * the inotify & libnotify APIs. Ideally, we should use the event mask, read in
+ * from our programs settings instead of hardcoding. Additionally, we should
+ * adjust the `display_notification` function so that it can prepare a
+ * notification message that also utilizes the events mask read in
+ * from the programs setting. This can be done in an idiomatic fashion. Lastly,
+ * the system logs to `journal` can be moved into the `display_notification`
+ * function.
+ */
 int handle_events(EventState *state) {
   char buf[4096] __attribute__((aligned(__alignof__(struct inotify_event))));
   const struct inotify_event *event;

--- a/src/event.c
+++ b/src/event.c
@@ -1,5 +1,6 @@
 #include "event.h"
 #include "config.h"
+#include "notify.h"
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
@@ -144,10 +145,21 @@ int handle_events(EventState *state) {
       }
 
       if (event->mask & IN_ACCESS) {
+        int status = display_notification(path, "Was accessed");
+        if (status != 0) {
+          syslog(LOG_WARNING, "Failed to display file system access event. "
+                              "Note: event logged to journal\n");
+        }
+
         syslog(LOG_INFO, "%s was accessed!\n", path);
       }
 
       if (event->mask & IN_MODIFY) {
+        int status = display_notification(path, "Was modified");
+        if (status != 0) {
+          syslog(LOG_WARNING, "Failed to display 'modify' file system event. "
+                              "Note: event logged to journal");
+        }
         syslog(LOG_INFO, "%s was modifed!\n", path);
       }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -16,15 +16,15 @@ void handle_signal(int sig) {
   case SIGINT:
   case SIGKILL:
   case SIGABRT:
-    syslog(LOG_INFO, "Exit signal [%d] received\n", sig);
+    syslog(LOG_INFO, "Exit signal [%d] received", sig);
     running = 0;
     break;
   case SIGHUP:
-    syslog(LOG_INFO, "Configuration reload signal [%d] received\n", sig);
+    syslog(LOG_INFO, "Configuration reload signal [%d] received", sig);
     running = 0;
     break;
   default:
-    syslog(LOG_WARNING, "Recieved unexpected signal [%d]\n", sig);
+    syslog(LOG_WARNING, "Recieved unexpected signal [%d]", sig);
     break;
   }
 }
@@ -39,21 +39,21 @@ int main(int argc, char **argv) {
 
   int sig_status = init_signals(&sa);
   if (sig_status != 0) {
-    syslog(LOG_ERR, "Failed to initialize signals\n");
+    syslog(LOG_ERR, "Failed to initialize signals");
     free_config(cfg);
     exit(sig_status);
   }
 
   EventState *state = start_event_listener(cfg);
   if (state == NULL) {
-    syslog(LOG_ERR, "Failed to start file event listener\n");
+    syslog(LOG_ERR, "Failed to start file event listener");
     free_config(cfg);
     exit(EXT_START_LISTENER);
   }
 
   int notif_status = init_notif();
   if (notif_status != 0) {
-    syslog(LOG_ERR, "Failed to initalize notifications\n");
+    syslog(LOG_ERR, "Failed to initalize notifications");
     stop_event_listener(state);
     free_config(cfg);
     uninit_notif();
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
         continue;
       }
 
-      syslog(LOG_ERR, "Failed to poll file descriptor for inotify events\n");
+      syslog(LOG_ERR, "Failed to poll file descriptor for inotify events");
       running = 0;
     }
 
@@ -78,13 +78,13 @@ int main(int argc, char **argv) {
       int event_status = handle_events(state);
 
       if (event_status != 0) {
-        syslog(LOG_ERR, "Failed to handle file events\n");
+        syslog(LOG_ERR, "Failed to handle file events");
         running = 0;
       }
     }
   }
 
-  syslog(LOG_INFO, "Cleaning up...\n");
+  syslog(LOG_INFO, "Cleaning up...");
   stop_event_listener(state);
   free_config(cfg);
   uninit_notif();

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "event.h"
+#include "notify.h"
 #include "util.h"
 #include <errno.h>
 #include <signal.h>
@@ -50,6 +51,15 @@ int main(int argc, char **argv) {
     exit(EXT_START_LISTENER);
   }
 
+  int notif_status = init_notif();
+  if (notif_status != 0) {
+    syslog(LOG_ERR, "Failed to initalize notifications\n");
+    stop_event_listener(state);
+    free_config(cfg);
+    uninit_notif();
+    exit(notif_status);
+  }
+
   // @TODO: rm config debugging once events are working as expected
   debug_config(cfg);
   while (running) {
@@ -77,5 +87,6 @@ int main(int argc, char **argv) {
   syslog(LOG_INFO, "Cleaning up...\n");
   stop_event_listener(state);
   free_config(cfg);
+  uninit_notif();
   exit(EXIT_SUCCESS);
 }

--- a/src/notify.c
+++ b/src/notify.c
@@ -24,7 +24,7 @@ int display_notification(const char *title, const char *body) {
   }
 
   notify_notification_set_timeout(notif, NOTIF_TIMEOUT_MS);
-  notify_notification_set_urgency(notif, NOTIFY_URGENCY_CRITICAL);
+  notify_notification_set_urgency(notif, NOTIFY_URGENCY_NORMAL);
 
   bool status = notify_notification_show(notif, NULL);
   if (!status) {

--- a/src/notify.c
+++ b/src/notify.c
@@ -7,7 +7,7 @@
 
 int init_notif(void) {
   if (!(notify_init("file-warden"))) {
-    syslog(LOG_ERR, "Failed to initialize libnotify\n");
+    syslog(LOG_ERR, "Failed to initialize libnotify");
     return EXT_INIT_NOTIF;
   }
 
@@ -19,7 +19,7 @@ void uninit_notif(void) { notify_uninit(); }
 int display_notification(const char *title, const char *body) {
   NotifyNotification *notif = notify_notification_new(title, body, NULL);
   if (notif == NULL) {
-    syslog(LOG_ERR, "Failed to create a new libnotify notification instance\n");
+    syslog(LOG_ERR, "Failed to create a new libnotify notification instance");
     return EXT_CREAT_NOTIF;
   }
 
@@ -28,7 +28,7 @@ int display_notification(const char *title, const char *body) {
 
   bool status = notify_notification_show(notif, NULL);
   if (!status) {
-    syslog(LOG_ERR, "Failed to display libnotify notification\n");
+    syslog(LOG_ERR, "Failed to display libnotify notification");
     g_object_unref(notif);
     return EXT_DISPLAY_NOTIF;
   }

--- a/src/notify.c
+++ b/src/notify.c
@@ -1,0 +1,38 @@
+#include "notify.h"
+#include "glib-object.h"
+#include <libnotify/notification.h>
+#include <libnotify/notify.h>
+#include <stdbool.h>
+#include <sys/syslog.h>
+
+int init_notif(void) {
+  if (!(notify_init("file-warden"))) {
+    syslog(LOG_ERR, "Failed to initialize libnotify\n");
+    return EXT_INIT_NOTIF;
+  }
+
+  return 0;
+}
+
+void uninit_notif(void) { notify_uninit(); }
+
+int display_notification(const char *title, const char *body) {
+  NotifyNotification *notif = notify_notification_new(title, body, NULL);
+  if (notif == NULL) {
+    syslog(LOG_ERR, "Failed to create a new libnotify notification instance\n");
+    return EXT_CREAT_NOTIF;
+  }
+
+  notify_notification_set_timeout(notif, NOTIF_TIMEOUT_MS);
+  notify_notification_set_urgency(notif, NOTIFY_URGENCY_CRITICAL);
+
+  bool status = notify_notification_show(notif, NULL);
+  if (!status) {
+    syslog(LOG_ERR, "Failed to display libnotify notification\n");
+    g_object_unref(notif);
+    return EXT_DISPLAY_NOTIF;
+  }
+
+  g_object_unref(notif);
+  return 0;
+}

--- a/src/util.c
+++ b/src/util.c
@@ -10,7 +10,8 @@
 
 int file_exists(const char *filename) {
   struct stat buf;
-  return (stat(filename, &buf) == 0);
+  int exists = stat(filename, &buf);
+  return exists == 0;
 }
 
 char *expand_path(const char *path) {
@@ -51,6 +52,7 @@ char *read_file(const char *filename) {
   char *buf = (char *)malloc(stat_buf.st_size + 1);
   if (buf == NULL) {
     syslog(LOG_ERR, "Failed to allocate memory for [%s] buffer\n", filename);
+    return NULL;
   }
 
   int fd = open(filename, O_RDONLY);

--- a/src/util.c
+++ b/src/util.c
@@ -16,13 +16,13 @@ int file_exists(const char *filename) {
 
 char *expand_path(const char *path) {
   if (strlen(path) == 0) {
-    syslog(LOG_ERR, "Cannot expand a path that is empty\n");
+    syslog(LOG_ERR, "Cannot expand a path that is empty");
     return NULL;
   }
 
   char *full_path = (char *)malloc(sizeof(char) * 512);
   if (full_path == NULL) {
-    syslog(LOG_ERR, "Failed to allocate memory for expanded path\n");
+    syslog(LOG_ERR, "Failed to allocate memory for expanded path");
     return NULL;
   }
 
@@ -33,7 +33,7 @@ char *expand_path(const char *path) {
 
   char *home_path = getenv("HOME");
   if (home_path == NULL) {
-    syslog(LOG_ERR, "Failed to find $HOME in list of env variables\n");
+    syslog(LOG_ERR, "Failed to find $HOME in list of env variables");
     return NULL;
   }
 
@@ -45,26 +45,26 @@ char *read_file(const char *filename) {
   struct stat stat_buf;
   int ok = stat(filename, &stat_buf);
   if (ok == -1) {
-    syslog(LOG_ERR, "File [%s] does not exist\n", filename);
+    syslog(LOG_ERR, "File [%s] does not exist", filename);
     return NULL;
   }
 
   char *buf = (char *)malloc(stat_buf.st_size + 1);
   if (buf == NULL) {
-    syslog(LOG_ERR, "Failed to allocate memory for [%s] buffer\n", filename);
+    syslog(LOG_ERR, "Failed to allocate memory for [%s] buffer", filename);
     return NULL;
   }
 
   int fd = open(filename, O_RDONLY);
   if (fd == -1) {
-    syslog(LOG_ERR, "Failed to open file [%s]\n", filename);
+    syslog(LOG_ERR, "Failed to open file [%s]", filename);
     free(buf);
     return NULL;
   }
 
   ssize_t bytes_read = read(fd, buf, stat_buf.st_size + 1);
   if (bytes_read == -1) {
-    syslog(LOG_ERR, "Failed to read file [%s]\n", filename);
+    syslog(LOG_ERR, "Failed to read file [%s]", filename);
     close(fd);
     free(buf);
     return NULL;


### PR DESCRIPTION
# Description 

The changes in this pull request expand on what was last developed by not only logging file system events to the `journal` but by displaying them `libnotify`. Libnotify will send the file system event message to the notification daemon and display the message. 