### PR TITLE
Desktop notifications

### DIFF
--- a/include/event.h
+++ b/include/event.h
@@ -29,19 +29,14 @@ typedef struct {
  * [fds] describes a polling request.
  * [poll_n] return value of [poll] used to monitor multiple file descriptors if
  * they are ready for reading.
- * [wd_map] look up table that links inotify watch
- * descriptors to paths. It provides a simple way to determine which path
- * triggered an event. [wd_entry_count] number of active elements contained in
- * [wd_map].
  */
 typedef struct {
   int fd;
   int *wd;
+  int wd_count;
   nfds_t nfds;
   struct pollfd fds[1];
   int poll_n;
-  WdEntry wd_map[MAX_WATCH_DESCRIPTORS];
-  int wd_entry_count;
 } EventState;
 
 /*
@@ -59,14 +54,6 @@ EventState *start_event_listener(Config *cfg);
  * [state].
  */
 void stop_event_listener(EventState *state);
-
-/*
- * Uses input [state] and [wd] to retrieve the path name that is linked to
- * inotify watch descriptor [wd]. If no mapping is found, NULL is returned.
- * Otherwise a pointer to the path is returned from field [wd_map] contained in
- * [state].
- */
-char *get_wd_path_mapping(EventState *state, int wd);
 
 /*
  * Handles file system events using the inotify API. It continuously reads

--- a/include/notify.h
+++ b/include/notify.h
@@ -1,32 +1,50 @@
 #ifndef NOTIFY_H
 #define NOTIFY_H
 
+#include "util.h"
 #include <libnotify/notification.h>
+#include <sys/inotify.h>
 
 /* Exit/Err codes */
 #define EXT_INIT_NOTIF 10
 #define EXT_CREAT_NOTIF 11
 #define EXT_DISPLAY_NOTIF 12
+#define EXT_SHOW_NOTIF 12
 
 /* Time, in MS, before notification is removed from screen */
 #define NOTIF_TIMEOUT_MS 3000
 
+#define MAX_NOTIF_MSG_LEN 256
+
+typedef struct {
+  u32 event_flag;
+  char title[20];
+  char summary[40];
+} EventMessageMapping;
+
 /*
  * Wrapper function to init libnotify, invokes [notify_init]. Returns 0 if
- * successful, otherwise it will return [EXT_INIT_NOTIF] which is then used as
- * an exit code.
+ * successful, otherwise it will return [EXT_INIT_NOTIF] exit code.
  */
-int init_notif(void);
+int init_libnotify(void);
 
 /*
  * Wrapper function to uninitialize libnotify, invokes [notify_uninit].
  */
-void uninit_notif(void);
+void uninit_libnotify(void);
 
 /*
- * Creates a new [NotifyNotification] struct using input [title] and [body]
- * as the text that will displayed in the notification.
+ * Processes input [event] and sends corresponding notification to the
+ * notification daemon. Returns 0 on success. Otherwise a non-zero int is
+ * returned
  */
-int display_notification(const char *title, const char *body);
+int notify(const struct inotify_event *event);
+
+/*
+ * Sends a desktop notification with the specified [title] and [body]. The
+ * function utilizes libnotify apis to create and display a desktop
+ * notification.
+ */
+int send_notification(const char *title, const char *body);
 
 #endif

--- a/include/util.h
+++ b/include/util.h
@@ -6,7 +6,7 @@
 
 #define EXT_INIT_SIGNALS 8
 
-typedef uint8_t u8;
+typedef uint32_t u32;
 
 typedef struct {
   int signal;

--- a/src/config.c
+++ b/src/config.c
@@ -113,8 +113,8 @@ int process_settings(Config *cfg, const char *settings) {
     return EXT_NULL_CFG;
   }
 
-  char buf[MAX_OPT_LINE_LEN];
-  if (strlen(settings) >= MAX_OPT_LINE_LEN) {
+  char buf[MAX_OPT_LINE_LEN] = {0};
+  if (strlen(settings) >= MAX_OPT_LINE_LEN - 1) {
     syslog(LOG_ERR, "Option settings line [%s] exceeds [%d] bytes", settings,
            MAX_OPT_LINE_LEN);
     return EXT_OPT_FORMAT;
@@ -273,6 +273,6 @@ void debug_config(Config *cfg) {
   }
 
   if (cfg->events_mask & IN_DELETE) {
-    syslog(LOG_DEBUG, "File create event flag enabled");
+    syslog(LOG_DEBUG, "File delete event flag enabled");
   }
 }

--- a/src/config.c
+++ b/src/config.c
@@ -3,18 +3,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/inotify.h>
 #include <sys/stat.h>
 #include <sys/syslog.h>
 
 /* Configuration options (tbd if more will be added) */
 static const char *OPT_PATHS = "paths";
 static const char *OPT_EVENTS = "events";
-
-/* Permitted file events for [OPT_EVENTS] option setting */
-static const char *EVENT_ACCESS = "accessed";
-static const char *EVENT_MODIFY = "modified";
-static const char *EVENT_MOVE = "moved";
-static const char *EVENT_CLOSE = "closed";
 
 /*
  * Configuration files can be stored in either location.
@@ -69,19 +64,26 @@ void free_config(Config *cfg) {
 }
 
 char *get_config_settings(Config *cfg) {
-  int in_home = file_exists(CFG_HOME_PATH);
+  char *exp_home_path = expand_path(CFG_HOME_PATH);
+  if (exp_home_path == NULL) {
+    syslog(LOG_ERR, "Failed to read config settings");
+    return NULL;
+  }
+
+  int in_home = file_exists(exp_home_path);
   int in_etc = file_exists(CFG_ETC_PATH);
 
-  // we should use the home configuration first since it's user specific
-  // and defer to system configuration if home file is not present.
+  // Convention is to use home (user) configuration first.
+  // If no user config, we can proceed with checking for etc (system-wide) cfg.
+  // Lastly, if neither are present. We will defer to the default settings
   if (in_home || in_etc) {
     cfg->config_location = in_home ? CFG_LOC_HOME : CFG_LOC_ETC;
 
-    char *settings = read_file(in_home ? CFG_HOME_PATH : CFG_ETC_PATH);
+    char *settings = read_file(in_home ? exp_home_path : CFG_ETC_PATH);
     if (settings != NULL) {
       syslog(LOG_INFO, "Using config file at [%s]",
-             in_home ? CFG_HOME_PATH : CFG_ETC_PATH);
-
+             in_home ? exp_home_path : CFG_ETC_PATH);
+      free(exp_home_path);
       return settings;
     }
 
@@ -92,6 +94,8 @@ char *get_config_settings(Config *cfg) {
   syslog(LOG_WARNING,
          "Config files may not exist.\nPlease create or copy the example "
          "config.\nDeferring to sensible default settings");
+
+  free(exp_home_path);
 
   // Sensible default if the config files are not present.
   cfg->config_location = CFG_LOC_DEFAULT;
@@ -110,7 +114,13 @@ int process_settings(Config *cfg, const char *settings) {
   }
 
   char buf[MAX_OPT_LINE_LEN];
-  strcpy(buf, settings);
+  if (strlen(settings) >= MAX_OPT_LINE_LEN) {
+    syslog(LOG_ERR, "Option settings line [%s] exceeds [%d] bytes", settings,
+           MAX_OPT_LINE_LEN);
+    return EXT_OPT_FORMAT;
+  } else {
+    strncpy(buf, settings, MAX_OPT_LINE_LEN);
+  }
 
   char *line = strtok(buf, "\n");
   while (line != NULL) {
@@ -137,7 +147,7 @@ int process_line_option(Config *cfg, char *line) {
 
   strncpy(key, line, equal_sign - line);
   key[equal_sign - line] = '\0';
-  u8 opt_flag = validate_option(key);
+  u32 opt_flag = validate_option(key);
   if (opt_flag == FLAG_INVAL_OPT) {
     syslog(LOG_WARNING, "Invalid option setting [%s]", key);
   }
@@ -154,7 +164,7 @@ int process_line_option(Config *cfg, char *line) {
   return 0;
 }
 
-u8 validate_option(char *setting_key) {
+u32 validate_option(char *setting_key) {
   if (strcmp(setting_key, OPT_PATHS) == 0) {
     return FLAG_PATHS_OPT;
   }
@@ -167,7 +177,7 @@ u8 validate_option(char *setting_key) {
   return 0;
 }
 
-int set_option(Config *cfg, u8 option_flag, char *value) {
+int set_option(Config *cfg, u32 option_flag, char *value) {
   if (option_flag & FLAG_PATHS_OPT) {
     return set_paths_option(cfg, value);
   }
@@ -202,15 +212,14 @@ int set_paths_option(Config *cfg, char *value) {
 }
 
 int set_events_option(Config *cfg, char *value) {
-  const FileEventMapping events[] = {{EVENT_ACCESS, FLAG_ACCESS},
-                                     {EVENT_MODIFY, FLAG_MODIFY},
-                                     {EVENT_MOVE, FLAG_MOVE},
-                                     {EVENT_CLOSE, FLAG_CLOSE},
-                                     {NULL, 0}};
+  FSEventMapping events[8] = {{"open", IN_OPEN},     {"access", IN_ACCESS},
+                              {"modify", IN_MODIFY}, {"close", IN_CLOSE},
+                              {"move", IN_MOVE},     {"create", IN_CREATE},
+                              {"delete", IN_DELETE}, {0, 0}};
 
-  for (int i = 0; events[i].name != NULL; i++) {
+  for (int i = 0; events[i].flag != 0 && events[i].name != 0; i++) {
     if (strcmp(value, events[i].name) == 0) {
-      cfg->events_bmask |= events[i].flag;
+      cfg->events_mask |= events[i].flag;
       break;
     }
   }
@@ -224,8 +233,7 @@ void debug_config(Config *cfg) {
   }
 
   syslog(LOG_DEBUG, "Paths option settings");
-  syslog(LOG_DEBUG, "Number of paths set for monitoring [%d]",
-         cfg->paths_size);
+  syslog(LOG_DEBUG, "Number of paths set for monitoring [%d]", cfg->paths_size);
 
   for (int i = 0; i < cfg->paths_size; i++) {
     syslog(LOG_DEBUG, "Path @ index [%d] contains value [%s]", i,
@@ -233,26 +241,38 @@ void debug_config(Config *cfg) {
   }
 
   syslog(LOG_DEBUG, "File event option settings");
-  if (cfg->events_bmask == 0) {
+  if (cfg->events_mask == 0) {
     syslog(LOG_DEBUG, "File event flags are not enabled");
     return;
   } else {
-    syslog(LOG_DEBUG, "File Event Bit Flags [0x%08X]", cfg->events_bmask);
+    syslog(LOG_DEBUG, "File Event Bit Flags [0x%08X]", cfg->events_mask);
   }
 
-  if (cfg->events_bmask & FLAG_ACCESS) {
+  if (cfg->events_mask & IN_ACCESS) {
     syslog(LOG_DEBUG, "File access event flag enabled");
   }
 
-  if (cfg->events_bmask & FLAG_MODIFY) {
+  if (cfg->events_mask & IN_MODIFY) {
     syslog(LOG_DEBUG, "File modify event flag enabled");
   }
 
-  if (cfg->events_bmask & FLAG_MOVE) {
+  if (cfg->events_mask & IN_MOVE) {
     syslog(LOG_DEBUG, "File move event flag enabled");
   }
 
-  if (cfg->events_bmask & FLAG_CLOSE) {
+  if (cfg->events_mask & IN_CLOSE) {
     syslog(LOG_DEBUG, "File close event flag enabled");
+  }
+
+  if (cfg->events_mask & IN_OPEN) {
+    syslog(LOG_DEBUG, "File open event flag enabled");
+  }
+
+  if (cfg->events_mask & IN_CREATE) {
+    syslog(LOG_DEBUG, "File create event flag enabled");
+  }
+
+  if (cfg->events_mask & IN_DELETE) {
+    syslog(LOG_DEBUG, "File create event flag enabled");
   }
 }

--- a/src/event.c
+++ b/src/event.c
@@ -38,8 +38,8 @@ EventState *start_event_listener(Config *cfg) {
       return NULL;
     }
 
-    // @TODO: utilize configuration events instead of hardcoding the event mask
-    state->wd[i] = inotify_add_watch(state->fd, cfg->paths[i], IN_ACCESS);
+    state->wd[i] =
+        inotify_add_watch(state->fd, cfg->paths[i], cfg->events_mask);
     if (state->wd[i] == -1) {
       syslog(LOG_ERR, "Failed to add [%s] to inotify watch list. [error: %s]",
              cfg->paths[i], strerror(errno));
@@ -110,18 +110,6 @@ char *get_wd_path_mapping(EventState *state, int wd) {
   return NULL;
 }
 
-/*
- * @TODO:(#8) event handler should use cfg option settings for notifications
- * Currently, the file system events that are listened to, by inotify, are
- * hardcoded. This was for testing purposes so that I could acclimate myself to
- * the inotify & libnotify APIs. Ideally, we should use the event mask, read in
- * from our programs settings instead of hardcoding. Additionally, we should
- * adjust the `display_notification` function so that it can prepare a
- * notification message that also utilizes the events mask read in
- * from the programs setting. This can be done in an idiomatic fashion. Lastly,
- * the system logs to `journal` can be moved into the `display_notification`
- * function.
- */
 int handle_events(EventState *state) {
   char buf[4096] __attribute__((aligned(__alignof__(struct inotify_event))));
   const struct inotify_event *event;
@@ -149,29 +137,9 @@ int handle_events(EventState *state) {
          ptr += sizeof(struct inotify_event) + event->len) {
       event = (const struct inotify_event *)ptr;
 
-      char *path = get_wd_path_mapping(state, event->wd);
-      if (path == NULL) {
-        syslog(LOG_ERR, "Failed to retrieve wd -> path mapping");
-        return -1;
-      }
-
-      if (event->mask & IN_ACCESS) {
-        int status = display_notification(path, "Was accessed");
-        if (status != 0) {
-          syslog(LOG_WARNING, "Failed to display file system access event. "
-                              "Note: event logged to journal");
-        }
-
-        syslog(LOG_INFO, "%s was accessed!", path);
-      }
-
-      if (event->mask & IN_MODIFY) {
-        int status = display_notification(path, "Was modified");
-        if (status != 0) {
-          syslog(LOG_WARNING, "Failed to display 'modify' file system event. "
-                              "Note: event logged to journal");
-        }
-        syslog(LOG_INFO, "%s was modifed!", path);
+      int status = notify(event);
+      if (status != 0) {
+        syslog(LOG_WARNING, "Failed send event to notification daemon");
       }
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -51,12 +51,12 @@ int main(int argc, char **argv) {
     exit(EXT_START_LISTENER);
   }
 
-  int notif_status = init_notif();
+  int notif_status = init_libnotify();
   if (notif_status != 0) {
     syslog(LOG_ERR, "Failed to initalize notifications");
     stop_event_listener(state);
     free_config(cfg);
-    uninit_notif();
+    uninit_libnotify();
     exit(notif_status);
   }
 
@@ -87,6 +87,6 @@ int main(int argc, char **argv) {
   syslog(LOG_INFO, "Cleaning up...");
   stop_event_listener(state);
   free_config(cfg);
-  uninit_notif();
+  uninit_libnotify();
   exit(EXIT_SUCCESS);
 }

--- a/src/notify.c
+++ b/src/notify.c
@@ -3,9 +3,10 @@
 #include <libnotify/notification.h>
 #include <libnotify/notify.h>
 #include <stdbool.h>
+#include <string.h>
 #include <sys/syslog.h>
 
-int init_notif(void) {
+int init_libnotify(void) {
   if (!(notify_init("file-warden"))) {
     syslog(LOG_ERR, "Failed to initialize libnotify");
     return EXT_INIT_NOTIF;
@@ -14,9 +15,9 @@ int init_notif(void) {
   return 0;
 }
 
-void uninit_notif(void) { notify_uninit(); }
+void uninit_libnotify(void) { notify_uninit(); }
 
-int display_notification(const char *title, const char *body) {
+int send_notification(const char *title, const char *body) {
   NotifyNotification *notif = notify_notification_new(title, body, NULL);
   if (notif == NULL) {
     syslog(LOG_ERR, "Failed to create a new libnotify notification instance");
@@ -34,5 +35,51 @@ int display_notification(const char *title, const char *body) {
   }
 
   g_object_unref(notif);
+  return 0;
+}
+
+int notify(const struct inotify_event *event) {
+  if (event->len <= 0) {
+    return 0;
+  }
+
+  size_t remaining = MAX_NOTIF_MSG_LEN - 1;
+  char notif_msg[MAX_NOTIF_MSG_LEN] = {0};
+
+  if (strlen(event->name) >= remaining) {
+    syslog(LOG_ERR, "Event name exceeds max summary message length [%d]",
+           MAX_NOTIF_MSG_LEN);
+    return EXT_SHOW_NOTIF;
+  }
+
+  if (event->mask & IN_ISDIR) {
+    strncat(notif_msg, "Directory (", remaining);
+  } else {
+    strncat(notif_msg, "File (", remaining);
+  }
+
+  remaining -= strlen(notif_msg) - 1;
+  strncat(notif_msg, event->name, remaining);
+
+  EventMessageMapping ev[7] = {
+      {IN_OPEN, "Open Alert!", ") was opened!"},
+      {IN_CLOSE_WRITE, "Close Alert!", ") was written to and closed!"},
+      {IN_CLOSE_NOWRITE, "Close Alert!", ") was not written to and closed!"},
+      {IN_CREATE, "Create Alert!", ") was created!"},
+      {IN_DELETE, "Delete Alert!", ") was deleted!"},
+      {IN_MOVE, "Move Alert!", ") was moved!"},
+      {0, "", ""},
+  };
+
+  for (int i = 0; ev[i].event_flag != 0; i++) {
+    if (event->mask & ev[i].event_flag) {
+      remaining -= strlen(notif_msg) - 1;
+      strncat(notif_msg, ev[i].summary, remaining);
+
+      syslog(LOG_INFO, "%s %s", ev[i].title, ev[i].summary);
+      return send_notification(ev[i].title, notif_msg);
+    }
+  }
+
   return 0;
 }


### PR DESCRIPTION
# Description 

The last merge request introduced libnotify so that we could push messages to the notification daemon. A notification is triggered if specific system calls were executed within paths that the program was monitoring. For example, if file-warden is watching a path (`~/dir/a/`) and a **read**, **write**, **open**, or **close**  call occurred on any file/dir within `~/dir/a/`, then a corresponding desktop notification would be displayed. The notification contains information such as the event that was triggered and the name of the file or directory. 

The previous version of file-warden only listened for one file system event. The changes in this pr add support for most of the inotify events. 


