### PR TITLE
AUR Prep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,25 @@
 CC=gcc
-
 SRC_DIR = src
 BUILD_DIR = build
 INCLUDE_DIR = include
+BIN = file-warden
 
-C_FLAGS = -Wall -pedantic -std=gnu99 -I$(INCLUDE_DIR)
-
-C_SOURCES = $(shell find $(SRC_DIR) -name '*.c')
-OBJS = $(C_SOURCES:$(SRC_DIR)%.c=$(BUILD_DIR)%.o)
+CFLAGS = -Wall -pedantic -std=gnu99 -I$(INCLUDE_DIR)
+SOURCES = $(shell find $(SRC_DIR) -name '*.c')
+OBJS      = $(patsubst $(SRC_DIR)/%.c,$(BUILD_DIR)/%.o,$(SOURCES))
 LIBS = $(shell pkg-config --cflags --libs libnotify)
-
 EXEC = $(BUILD_DIR)/file-warden
 
 all: $(EXEC)
 
-$(EXEC): $(C_SOURCES)
+$(EXEC): $(SOURCES)
 	@mkdir -p $(BUILD_DIR)
-	$(CC) $(C_SOURCES) -o $(EXEC) $(C_FLAGS) $(LIBS)
+	$(CC) $(SOURCES) -o $(EXEC) $(CFLAGS) $(LIBS)
 
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
-	$(CC) -c $< -o $@ $(C_FLAGS)
+	$(CC) -c $< -o $@ $(CFLAGS)
 
 clean:
 	rm -r $(BUILD_DIR)
 
-run:
-	@$(EXEC)
-
-.phony: all clean run
+.phony: all clean


### PR DESCRIPTION
# Description

The changes to the makefile address a couple matters
1. Incremental builds/compilation were never working :joy:. Object files were never created or properly linked. This has been resolved.
2. Install target was missing so that we could install the binary to a specified directory. Such as `/usr/local/bin/file-warden`

After some additional testing, I will submit a PKGBUILD file to the aur so that file-warden can be installed with `makepkg` or any aur helper. 